### PR TITLE
ci: don't fix lint Error on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,4 +29,4 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       # run only lint
-      - run: yarn lint
+      - run: yarn ci:lint

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
+    "ci:lint": "vue-cli-service lint --no-fix",
     "electron:build": "vue-cli-service electron:build",
     "electron:serve": "vue-cli-service electron:serve",
     "postinstall": "electron-builder install-app-deps",


### PR DESCRIPTION
- CIでのlintでautofix機能が走ってしまい、本来検出すべきエラーが検出できてなかった。
- CIではautofixをオフにした