### PR TITLE
build portable exe for Win

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -2,6 +2,9 @@ module.exports = {
   pluginOptions: {
     electronBuilder: {
       builderOptions: {
+        win: {
+          target: 'portable'
+        }
       }
     }
   }


### PR DESCRIPTION
Windowsのビルドでポータブルなexeファイルを生成するようにしました。
※元々はsetup.exeが生成され、それを実行すると実行可能なアプリケーションが展開される形式だった

参考: https://www.electron.build/configuration/win