### PR TITLE
Feat/unify audio context

### DIFF
--- a/src/components/BGMBox.vue
+++ b/src/components/BGMBox.vue
@@ -19,7 +19,7 @@
           <v-btn-toggle multiple>
             <PlayingToggle
               v-if="source"
-              :isPlaying="isPlaying()"
+              :isPlaying="isPlaying"
               @play-sound="playSound"
               @pause-sound="pauseSound"
             />
@@ -32,7 +32,7 @@
         <v-flex>
           <ProgressTime
             v-if="source"
-            :currentTime="currentTime"
+            :currentTime="currentTime()"
             :endTime="source.buffer.duration"
           />
         </v-flex>
@@ -49,7 +49,7 @@
       <v-layout>
         <v-flex>
           <PlayingIndicator
-            :isPlaying="isPlaying()"
+            :isPlaying="isPlaying"
           />
         </v-flex>
       </v-layout>
@@ -91,16 +91,12 @@ export default {
   },
   methods: {
     playSound () {
-      this.resumeSound()
-      if (!this.isStarted) {
-        this.source.start()
-        this.isStarted = true
-      }
+      this.startSource(this.currentTime())
       this.startCurrentTimeInterval()
       this.$emit('play-sound')
     },
     pauseSound () {
-      this.suspendSound()
+      this.stopSource()
       this.clearCurrentTimeInterval()
     }
   }

--- a/src/components/BGMList.vue
+++ b/src/components/BGMList.vue
@@ -3,6 +3,7 @@
     <v-flex xs6 md4 pa-1 v-for="(sound, index) in sounds" :key="sound.filePath">
       <BGMBox
         ref="soundBoxes"
+        :context="context"
         :filePath="sound.filePath"
         :volume="sound.volume"
         @play-sound="pauseOtherBGMs(index)"

--- a/src/components/SEBox.vue
+++ b/src/components/SEBox.vue
@@ -19,7 +19,7 @@
           <v-btn-toggle multiple>
           <PlayingToggle
             v-if="source"
-            :isPlaying="isPlaying()"
+            :isPlaying="isPlaying"
             @play-sound="playSound"
           />
             <VolumeControlToggle
@@ -41,7 +41,7 @@
       <v-layout>
         <v-flex>
           <PlayingIndicator
-            :isPlaying="isPlaying()"
+            :isPlaying="isPlaying"
           />
         </v-flex>
       </v-layout>
@@ -78,11 +78,9 @@ export default {
   },
   methods: {
     playSound () {
-      this.resumeSound()
-      this.source.start()
+      this.startSource(0)
       this.source.onended = () => {
-        this.suspendSound()
-        this.reloadSource()
+        this.stopSource()
       }
     }
   }

--- a/src/components/SEList.vue
+++ b/src/components/SEList.vue
@@ -2,6 +2,7 @@
   <v-layout wrap>
     <v-flex xs12 pa-1 v-for="(sound, index) in sounds" :key="sound.filePath">
       <SEBox
+        :context="context"
         :filePath="sound.filePath"
         :volume="sound.volume"
         @remove-sound="removeSound(index)"

--- a/src/mixins/HasCurrentTime.js
+++ b/src/mixins/HasCurrentTime.js
@@ -1,18 +1,27 @@
+let startTime = 0
+let stackTime = 0
+let currentTimeIntervalId = null
+
 export default {
   data () {
     return {
-      currentTime: 0,
-      currentTimeIntervalId: null
+      playingTime: 0
     }
   },
   methods: {
     startCurrentTimeInterval () {
-      this.currentTimeIntervalId = setInterval(() => {
-        this.currentTime = this.context.currentTime
+      startTime = this.context.currentTime
+      currentTimeIntervalId = setInterval(() => {
+        this.playingTime = this.context.currentTime - startTime
       }, 200)
     },
     clearCurrentTimeInterval () {
-      clearInterval(this.currentTimeIntervalId)
+      stackTime = stackTime + this.playingTime
+      this.playingTime = 0
+      clearInterval(currentTimeIntervalId)
+    },
+    currentTime () {
+      return stackTime + this.playingTime
     }
   },
   beforeDestroy () {

--- a/src/mixins/SoundBox.js
+++ b/src/mixins/SoundBox.js
@@ -4,12 +4,12 @@ const fs = electron.remote.require('fs')
 
 export default {
   props: {
+    context: AudioContext,
     filePath: String,
     volume: Number
   },
   data () {
     return {
-      context: new AudioContext(),
       source: null,
       gainNode: null,
       isPlaying: false,
@@ -19,7 +19,6 @@ export default {
     }
   },
   created () {
-    this.context.onstatechange = () => this.$forceUpdate()
     fs.readFile(this.filePath, (error, data) => {
       if (error) {
         console.error(error)
@@ -34,9 +33,6 @@ export default {
         this.gainNode.connect(this.context.destination)
       }).then()
     })
-  },
-  beforeDestroy () {
-    this.context.close()
   },
   methods: {
     removeSound () {

--- a/src/mixins/SoundList.js
+++ b/src/mixins/SoundList.js
@@ -1,5 +1,6 @@
 export default {
   props: {
+    context: AudioContext,
     sounds: Array
   },
   methods: {

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -17,6 +17,7 @@
     <v-layout wrap>
       <v-flex xs10>
         <BGMList
+          :context="context"
           :sounds="BGMs"
           @add-sound="addBGM"
           @remove-sound="removeBGM"
@@ -25,6 +26,7 @@
       </v-flex>
       <v-flex xs2>
         <SEList
+          :context="context"
           :sounds="SEs"
           @add-sound="addSE"
           @remove-sound="removeSE"
@@ -156,10 +158,12 @@ export default {
     }
   },
   created () {
+    this.context.onstatechange = () => this.$forceUpdate()
     this.loadSoundList()
   },
   data () {
     return {
+      context: new AudioContext(),
       soundListName: 'default',
       BGMs: [],
       SEs: [],


### PR DESCRIPTION
SoundBox ごとに AudioContext 持ってたのを Main で1つだけ持つように変更しました。

理由は2点です。
- 出力先変更の対応にあたって AudioContext が複数あると面倒なため。
- > ひとつのAudioContextインスタンスで、複数の音声入力と複雑なオーディオグラフに対応できるので、オーディオアプリケーションを開発する際には、通常ひとつのインスタンスしか必要ありません。
  https://www.html5rocks.com/ja/tutorials/webaudio/intro/

再生時間の管理を AudioContext に頼ってたのを自前で実装したのでそのあたりの変更が大きいです。