### PR TITLE
:sparkles: reset progress time

### DIFF
--- a/src/components/BGMBox.vue
+++ b/src/components/BGMBox.vue
@@ -23,6 +23,9 @@
               @play-sound="playSound"
               @pause-sound="pauseSound"
             />
+            <ProgressTimeResetter
+              @reset-progress-time="resetProgressTime"
+            />
             <VolumeControlToggle
               :isOpened="isVolumeControlOpened"
               @toggle-volume-control="toggleVolumeControl"
@@ -65,6 +68,7 @@ import PlayingToggle from '@/components/PlayingToggle.vue'
 import VolumeControlToggle from '@/components/VolumeControlToggle.vue'
 import VolumeControl from '@/components/VolumeControl.vue'
 import ProgressTime from '@/components/ProgressTime.vue'
+import ProgressTimeResetter from '@/components/ProgressTimeResetter'
 import PlayingIndicator from '@/components/PlayingIndicator.vue'
 import CurrentTimeCounter from '@/services/CurrentTimeCounter'
 
@@ -80,6 +84,7 @@ export default {
     VolumeControlToggle,
     VolumeControl,
     ProgressTime,
+    ProgressTimeResetter,
     PlayingIndicator
   },
   data () {
@@ -110,6 +115,14 @@ export default {
       }
       this.stopSource()
       this.currentTimeCounter.clear()
+    },
+    resetProgressTime () {
+      const keepPlaying = this.isPlaying
+      this.pauseSound()
+      this.currentTimeCounter.backToZero()
+      if (keepPlaying) {
+        this.playSound()
+      }
     }
   }
 }

--- a/src/components/ProgressTimeResetter.vue
+++ b/src/components/ProgressTimeResetter.vue
@@ -1,0 +1,19 @@
+<template>
+  <v-btn @click="emit" color="grey darken-2">
+    <v-icon>replay</v-icon>
+  </v-btn>
+</template>
+
+<script>
+export default {
+  name: 'ProgressTimeResetter',
+  methods: {
+    emit () {
+      this.$emit('reset-progress-time')
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/src/services/CurrentTimeCounter.js
+++ b/src/services/CurrentTimeCounter.js
@@ -14,13 +14,24 @@ export default class CurrentTimeCounter {
     this.#startTime = this.context.currentTime
     this.#intervalId = setInterval(() => {
       this.#playingTime = this.context.currentTime - this.#startTime
-      this.setter(this.#stackTime + this.#playingTime)
+      this.update()
     }, 200)
+  }
+
+  update () {
+    this.setter(this.#stackTime + this.#playingTime)
   }
 
   clear () {
     this.#stackTime = this.#stackTime + this.#playingTime
     this.#playingTime = 0
     clearInterval(this.#intervalId)
+  }
+
+  backToZero () {
+    this.#startTime = 0
+    this.#stackTime = 0
+    this.#playingTime = 0
+    this.update()
   }
 }


### PR DESCRIPTION
Fixed #49 .(issue ID)

## Purpose
- 再生時間のリセット機能です。
- 再生中にリセットされても継続して再生します。

## Extra Messages
- ボタンの見た目（Active/Inactive）がなんかおかしいですが、既存仕様の影響なので別の PR で直します。

@gimKondo (or some reviewers)
