### PR TITLE
Feat/use toast for none prompt ui

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -114,7 +114,7 @@ function playDiscordSound (connection, filePath, volume, offset) {
   })
 }
 
-ipcMain.on('discordJoin', (event, data) => {
+ipcMain.handle('discordJoin', async (event, data) => {
   discordClient.on('message', async message => {
     const msgType = DiscordMsg.judgeType(message.content)
     switch (msgType) {
@@ -158,21 +158,22 @@ ipcMain.on('discordJoin', (event, data) => {
     } else {
       dialog.showMessageBox({ type: 'error', detail: error })
     }
-    return
+    return { isSuccess: false }
   }
 
   try {
     const config = ini.parse(fs.readFileSync(pathConfig, 'utf-8'))
-    discordClient.login(config.discordToken)
-      .then((data) => {
-        dialog.showMessageBox({ type: 'info', detail: 'Success Discord Login.Please type ":soc: join" to discord workspace.' })
-      })
-      .catch((e) => {
-        dialog.showMessageBox({ type: 'error', detail: `The token is illegal.\nPlease check to ${pathConfig}` })
-      })
+    try {
+      await discordClient.login(config.discordToken)
+      console.log('Success to login Discord.')
+      return { isSuccess: true }
+    } catch (e) {
+      dialog.showMessageBox({ type: 'error', detail: `The token is illegal.\nPlease check to ${pathConfig}` })
+    }
   } catch (error) {
     dialog.showMessageBox({ type: 'error', detail: `The format is wrong.\nPlease check to ${pathConfig}\n${error}` })
   }
+  return { isSuccess: false }
 })
 
 let filePathCurrentPlay

--- a/src/mixins/SoundBox.js
+++ b/src/mixins/SoundBox.js
@@ -40,11 +40,11 @@ export default {
     removeSound () {
       this.$emit('remove-sound')
     },
-    isDisordAPI (deviceId) {
+    isDiscordAPI (deviceId) {
       return this.context.deviceId === DISCORD_DEVICE_ID
     },
     startSource (offset) {
-      if (this.isDisordAPI(this.context.deviceId)) {
+      if (this.isDiscordAPI(this.context.deviceId)) {
         ipcRenderer.send('discordPlay', { filePath: this.filePath, volume: this.volume, offset: offset })
       } else {
         this.source.start(undefined, offset)
@@ -52,7 +52,7 @@ export default {
       this.isPlaying = true
     },
     stopSource () {
-      if (this.isDisordAPI(this.context.deviceId)) {
+      if (this.isDiscordAPI(this.context.deviceId)) {
         ipcRenderer.send('discordStop', { filePath: this.filePath })
       } else {
         this.source.stop()
@@ -61,7 +61,7 @@ export default {
       this.isPlaying = false
     },
     reloadSource () {
-      if (this.isDisordAPI(this.context.deviceId)) {
+      if (this.isDiscordAPI(this.context.deviceId)) {
         ipcRenderer.send('discordPlay', { filePath: this.filePath, volume: 1, offset: 0 })
       } else {
         this.source = initializeSource(this.context, this.decodedSoundBuffer, this.loop)
@@ -71,7 +71,7 @@ export default {
     applyVolume (volume) {
       this.gain.gain.value = toRealVolume(volume)
       this.$emit('apply-volume', volume)
-      if (this.isDisordAPI(this.context.deviceId)) {
+      if (this.isDiscordAPI(this.context.deviceId)) {
         ipcRenderer.send('discordSoundChange', { filePath: this.filePath, volume: this.volume })
       }
     },

--- a/src/mixins/SoundBox.js
+++ b/src/mixins/SoundBox.js
@@ -72,7 +72,7 @@ export default {
       this.gain.gain.value = toRealVolume(volume)
       this.$emit('apply-volume', volume)
       if (this.isDisordAPI(this.context.deviceId)) {
-        ipcRenderer.send('discordSoundChange', { 'filePath': this.filePath, 'volume': this.volume })
+        ipcRenderer.send('discordSoundChange', { filePath: this.filePath, volume: this.volume })
       }
     },
     toggleVolumeControl () {

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -88,7 +88,13 @@ export default {
         this.channelSplitter.connect(destination)
         audio.play()
       } else {
-        ipcRenderer.send('discordJoin')
+        ipcRenderer.invoke('discordJoin').then(({ isSuccess }) => {
+          if (isSuccess) {
+            this.showSnackbar('Success to login Discord.\nPlease type ":soc: join" on discord text channel.', 'info')
+          }
+        }).catch((err) => {
+          this.showSnackbar(err, 'error')
+        })
       }
     },
     saveSoundList () {

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -78,8 +78,8 @@ export default {
   methods: {
     changeDestination (deviceId) {
       this.context.deviceId = deviceId
-      // Since there is no official API, use the hacky method.
       if (deviceId !== 'Discord API') {
+        // Since there is no official API, use the hacky method.
         const destination = this.context.createMediaStreamDestination()
         const audio = new Audio()
         audio.srcObject = destination.stream

--- a/vue.config.js
+++ b/vue.config.js
@@ -10,9 +10,9 @@ module.exports = {
           'node_modules/ffmpeg-static'
         ],
         extraFiles: {
-          'from': 'node_modules/ffmpeg-static',
-          'to': './Resources/app/node_modules/ffmpeg-static/',
-          'filter': ['**/*']
+          from: 'node_modules/ffmpeg-static',
+          to: './Resources/app/node_modules/ffmpeg-static/',
+          filter: ['**/*']
         },
         win: {
           target: 'portable'


### PR DESCRIPTION
## Purpose
- Discord APIを選択するたびにモーダルが出てくるのを抑止する

## Changes
- 成功時はモーダルではなくトースト(Snackbar)を出すように変更
  - そのために、discordJoinの成否を返せるように、ipc通信をinvoke/handle形式に変更
- ついでに細かい修正
  - typo
  - 不要なクォーテーションの除去