### PR TITLE
Feature/fix se on discord

### DIFF
--- a/src/mixins/SoundBox.js
+++ b/src/mixins/SoundBox.js
@@ -40,11 +40,11 @@ export default {
     removeSound () {
       this.$emit('remove-sound')
     },
-    isDiscordAPI (deviceId) {
+    isDiscordAPI () {
       return this.context.deviceId === DISCORD_DEVICE_ID
     },
     startSource (offset) {
-      if (this.isDiscordAPI(this.context.deviceId)) {
+      if (this.isDiscordAPI()) {
         ipcRenderer.send('discordPlay', { filePath: this.filePath, volume: this.volume, offset: offset, loop: this.loop })
         if (this.loop) {
           // Because rendering process cannot detect end of sound on Discord mode,
@@ -57,7 +57,7 @@ export default {
       }
     },
     stopSource () {
-      if (this.isDiscordAPI(this.context.deviceId)) {
+      if (this.isDiscordAPI()) {
         ipcRenderer.send('discordStop', { filePath: this.filePath })
       } else {
         this.source.stop()
@@ -66,7 +66,7 @@ export default {
       this.isPlaying = false
     },
     reloadSource () {
-      if (this.isDiscordAPI(this.context.deviceId)) {
+      if (this.isDiscordAPI()) {
         ipcRenderer.send('discordPlay', { filePath: this.filePath, volume: 1, offset: 0 })
       } else {
         this.source = initializeSource(this.context, this.decodedSoundBuffer, this.loop)
@@ -76,7 +76,7 @@ export default {
     applyVolume (volume) {
       this.gain.gain.value = toRealVolume(volume)
       this.$emit('apply-volume', volume)
-      if (this.isDiscordAPI(this.context.deviceId)) {
+      if (this.isDiscordAPI()) {
         ipcRenderer.send('discordSoundChange', { filePath: this.filePath, volume: this.volume })
       }
     },

--- a/src/mixins/SoundBox.js
+++ b/src/mixins/SoundBox.js
@@ -45,11 +45,16 @@ export default {
     },
     startSource (offset) {
       if (this.isDiscordAPI(this.context.deviceId)) {
-        ipcRenderer.send('discordPlay', { filePath: this.filePath, volume: this.volume, offset: offset })
+        ipcRenderer.send('discordPlay', { filePath: this.filePath, volume: this.volume, offset: offset, loop: this.loop })
+        if (this.loop) {
+          // Because rendering process cannot detect end of sound on Discord mode,
+          // don't turn isPlaying flag on for not looped sound.
+          this.isPlaying = true
+        }
       } else {
         this.source.start(undefined, offset)
+        this.isPlaying = true
       }
-      this.isPlaying = true
     },
     stopSource () {
       if (this.isDiscordAPI(this.context.deviceId)) {


### PR DESCRIPTION
Fixed #89 

## Purpose

- DiscordモードだとSEが無限ループしてしまう

## Changes

- SEの場合は1回再生したらDiscordでの再生を止める
- DiscordモードではSEの再生ボタンはトグルしない
  - 音声を1回で止める仕組みがDiscordモードでは特殊な扱いになってしまっている
  - 構造としては醜く、今後の拡張に害がありそうなので、もうちょっと検討してみる

## Extra Messages

#90 のBGM再生が止まってしまう問題は直っていない
