### PR TITLE
MANUAL.mdのドキュメントに具体的なブラウザを追加

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -6,7 +6,7 @@
 
 ### DiscordでBotアプリケーションの設定
 
-1. ブラウザで[Discordにログイン](https://discordapp.com/login)する
+1. Webブラウザ(Chrome・Firefoxなど)で[Discordにログイン](https://discordapp.com/login)する
 2. [Developer Portal](https://discord.com/developers/applications)でApplicationを作成し、Botを追加する
     - [公式リファレンス](https://discordjs.guide/preparations/setting-up-a-bot-application.html)を参照
     - アプリ名やBot名、アイコン等は任意で良い


### PR DESCRIPTION
## Purpose

Sound of Cthulhuのリンク(Manual)からElectronのブラウザでDiscordのDeveloper Portalへ遷移するとサイトが正しく動作しなかった。
これを防止するため、ユーザにSound of CthulhuのWebViewではなく、Webブラウザを使って操作してもらうようにする。

## Changes

マニュアルにWebブラウザを使うよう明示