### PR TITLE
ci: update modules and Node.js version on workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,23 +19,11 @@ jobs:
         os: [macOS-10.15, windows-2016]
 
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: v12.18.2
+          cache: "yarn"
+          node-version: v16.x
       - name: yarn install
         run: |
           yarn install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - "src/**"
+      - "package.json"
+      - "yarn.lock"
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,27 +18,16 @@ jobs:
         os: [macOS-10.15, windows-2016]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set release version
         run: echo ::set-env name=RELEASE_VERSION::$(cat package.json | jq -r '.version')
         shell: bash
 
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
+      - uses: actions/setup-node@v3
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: v12.18.2
+          cache: "yarn"
+          node-version: v16.x
       - name: yarn install
         run: |
           yarn install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Test
 
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "package.json"
+      - "yarn.lock"
 
 jobs:
   test:


### PR DESCRIPTION
## Changes

- update modules on build, test and release workflow
- update  Node.js version from 12.x to 16.x on build and release workflow
- limit trigger paths to prevent unnecessary test execution
