### PR TITLE
ci: set environment by new method on GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set release version
-        run: echo ::set-env name=RELEASE_VERSION::$(cat package.json | jq -r '.version')
         shell: bash
+        run: echo "RELEASE_VERSION=$(cat package.json | jq -r '.version')" >> $GITHUB_ENV
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Purpose

- use new style set-env on GitHub Actions
  - ref: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
