### PR TITLE
ci: use new mac os on GitHub acitons

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -1,0 +1,30 @@
+name: Create Release
+description: Create release for each OS
+inputs:
+  github_token:
+    description: "pass `secrets.GITHUB_TOKEN`"
+    required: true
+  release_version:
+    description: "release version(git tag)"
+    required: true
+  os_name:
+    description: "OS name(mac or win)"
+    required: true
+  file_path:
+    description: "File path to upload(dist_electron/sound-of-cthulhu*.dmg or dist_electron/sound-of-cthulhu*.exe)"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Build
+      shell: bash
+      run: yarn electron:build --publish never --${{ inputs.os_name }}
+      env:
+        USE_HARD_LINKS: "false"
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: ${{ inputs.file_path }}}
+        tag_name: ${{ inputs.release_version }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,6 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
 
-    env:
-      MAC_OS_VERSION: macOS-10.15
-      WIN_OS_VERSION: windows-latest
-
     strategy:
       matrix:
         # この中でenvにアクセスできないので直書き
@@ -27,13 +23,13 @@ jobs:
           yarn postinstall
 
       - name: Build for macOS
-        if: matrix.os == env.MAC_OS_VERSION
+        if: startsWith(matrix.os, 'mac')
         run: yarn electron:build --publish never --mac
         env:
           USE_HARD_LINKS: false
 
       - name: Build for Windows
-        if: matrix.os == env.WIN_OS_VERSION
+        if: startsWith(matrix.os, 'win')
         run: yarn electron:build --publish never --win
         env:
           USE_HARD_LINKS: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # この中でenvにアクセスできないので直書き
-        os: [macOS-10.15, windows-latest]
+        os: [macOS-11, windows-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,30 +29,20 @@ jobs:
           yarn install
           yarn postinstall
 
-      - name: Build for macOS
-        if: startsWith(matrix.os, 'mac')
-        run: yarn electron:build --publish never --mac
-        env:
-          USE_HARD_LINKS: false
       - name: Create GitHub Release(Mac)
         if: startsWith(matrix.os, 'mac')
-        uses: softprops/action-gh-release@v1
+        uses: ./.github/actions/create-release
         with:
-          files: "dist_electron/sound-of-cthulhu*.dmg"
-          tag_name: ${{ env.RELEASE_VERSION }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_version: ${{ env.RELEASE_VERSION }}
+          os_name: "mac"
+          file_path: "dist_electron/sound-of-cthulhu*.dmg"
 
-      - name: Build for Windows
+      - name: Create GitHub Release(Win)
         if: startsWith(matrix.os, 'win')
-        run: yarn electron:build --publish never --win
-        env:
-          USE_HARD_LINKS: false
-      - name: Create GitHub Release(Windows)
-        if: startsWith(matrix.os, 'win')
-        uses: softprops/action-gh-release@v1
+        uses: ./.github/actions/create-release
         with:
-          files: "dist_electron/sound-of-cthulhu*.exe"
-          tag_name: ${{ env.RELEASE_VERSION }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_version: ${{ env.RELEASE_VERSION }}
+          os_name: "win"
+          file_path: "dist_electron/sound-of-cthulhu*.exe"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,6 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
 
-    env:
-      MAC_OS_VERSION: macOS-10.15
-      WIN_OS_VERSION: windows-latest
-
     strategy:
       matrix:
         # この中でenvにアクセスできないので直書き
@@ -34,12 +30,12 @@ jobs:
           yarn postinstall
 
       - name: Build for macOS
-        if: matrix.os == env.MAC_OS_VERSION
+        if: startsWith(matrix.os, 'mac')
         run: yarn electron:build --publish never --mac
         env:
           USE_HARD_LINKS: false
       - name: Create GitHub Release(Mac)
-        if: matrix.os == env.MAC_OS_VERSION
+        if: startsWith(matrix.os, 'mac')
         uses: softprops/action-gh-release@v1
         with:
           files: "dist_electron/sound-of-cthulhu*.dmg"
@@ -48,12 +44,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build for Windows
-        if: matrix.os == env.WIN_OS_VERSION
+        if: startsWith(matrix.os, 'win')
         run: yarn electron:build --publish never --win
         env:
           USE_HARD_LINKS: false
       - name: Create GitHub Release(Windows)
-        if: matrix.os == env.WIN_OS_VERSION
+        if: startsWith(matrix.os, 'win')
         uses: softprops/action-gh-release@v1
         with:
           files: "dist_electron/sound-of-cthulhu*.exe"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # この中でenvにアクセスできないので直書き
-        os: [macOS-10.15, windows-latest]
+        os: [macOS-11, windows-latest]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Changes

- update Mac OS version 10.15 to 11
- refactor
  - use composite action to create GitHub release
  - use startsWith for judge OS instead of ENV
